### PR TITLE
install epel repo to satisfy inmanta-core openssl dependency

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,6 +4,7 @@ ENV container docker
 ARG inmanta_repo="inmanta_oss_stable.repo"
 COPY ${inmanta_repo} /etc/yum.repos.d/${INMANTA_REPO}
 
+RUN yum install -y epel-release
 RUN yum install -y python3-inmanta python3-inmanta-server postgresql
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
quickstart-docker fails for the next release because `inmanta-core` now requires EPEL (inmanta/inmanta-core#2518). Is this an appropriate solution or should epel be specified as a dependency of the RPM?
This is blocking the ISO4 release.